### PR TITLE
Fix issue #27

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
-  </component>
-</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/app/src/main/java/com/nitish/privacyindicator/fragments/FragmentHome.java
+++ b/app/src/main/java/com/nitish/privacyindicator/fragments/FragmentHome.java
@@ -1,6 +1,5 @@
 package com.nitish.privacyindicator.fragments;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
@@ -12,12 +11,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
-
 import com.github.dhaval2404.colorpicker.ColorPickerDialog;
 import com.github.dhaval2404.colorpicker.listener.ColorListener;
 import com.github.dhaval2404.colorpicker.model.ColorShape;
@@ -26,8 +23,6 @@ import com.nitish.privacyindicator.SharedPrefManager;
 import com.nitish.privacyindicator.services.IndicatorService;
 
 public class FragmentHome extends Fragment {
-
-    private static int LAUNCHED_ACCESSIBILITY_SETTINGS = 1;
 
     //Root Views
     private View root;
@@ -179,7 +174,7 @@ public class FragmentHome extends Fragment {
                 showGuidanceToast();
 
                 Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
-                startActivityForResult(intent, LAUNCHED_ACCESSIBILITY_SETTINGS);
+                startActivity(intent);
             }
         });
 

--- a/app/src/main/java/com/nitish/privacyindicator/fragments/FragmentHome.java
+++ b/app/src/main/java/com/nitish/privacyindicator/fragments/FragmentHome.java
@@ -1,5 +1,7 @@
 package com.nitish.privacyindicator.fragments;
 
+import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -9,12 +11,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CompoundButton;
-import android.widget.ImageView;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
-import android.widget.SeekBar;
-import android.widget.TextView;
+import android.widget.*;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -29,6 +26,8 @@ import com.nitish.privacyindicator.SharedPrefManager;
 import com.nitish.privacyindicator.services.IndicatorService;
 
 public class FragmentHome extends Fragment {
+
+    private static int LAUNCHED_ACCESSIBILITY_SETTINGS = 1;
 
     //Root Views
     private View root;
@@ -177,8 +176,10 @@ public class FragmentHome extends Fragment {
         mainSwitch.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                showGuidanceToast();
+
                 Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
-                startActivity(intent);
+                startActivityForResult(intent, LAUNCHED_ACCESSIBILITY_SETTINGS);
             }
         });
 
@@ -316,6 +317,15 @@ public class FragmentHome extends Fragment {
 
             }
         });
+    }
+
+    private void showGuidanceToast() {
+        Context context = getActivity().getApplicationContext();
+        CharSequence text = "Please enable \"Privacy Indicators\" under downloaded services section.";
+        int duration = Toast.LENGTH_LONG;
+
+        Toast toast = Toast.makeText(context, text, duration);
+        toast.show();
     }
 
     CompoundButton.OnCheckedChangeListener onCheckedChangeListener = new CompoundButton.OnCheckedChangeListener() {


### PR DESCRIPTION
After a couple of hours of research I was not able to find how to be able to highlight the row for our service in android settings, simply because we actually do not have control over the Settings activity and Android has not provided an action for highlighting custom services.

The next best thing that I was able to compe up wiht is to draw soemthing on the screen, but that won't be possible since our service would have to be already enabled in order to do that.

So I think that a simple guidance toast telling the user what to enable is sufficient here and that is what I have implemented.